### PR TITLE
Add z3 specific sequences and lambdas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[features]
+z3 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ mod propliteral;
 mod sort;
 mod term;
 mod variable;
+#[cfg(feature = "z3")]
+mod z3;
 
 pub use context::{Smt2Command, Smt2Context};
 pub use datatype::DataType;
@@ -53,6 +55,7 @@ pub use propliteral::PropLiteral;
 pub use sort::{Sort, SortDecl, SortDef};
 pub use term::{Attribute, MatchCase, Pattern, SortedVar, Term, VarBinding};
 pub use variable::VarDecl;
+pub use z3::theories::seq;
 
 /// defines a smtlib2 expression
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub use propliteral::PropLiteral;
 pub use sort::{Sort, SortDecl, SortDef};
 pub use term::{Attribute, MatchCase, Pattern, SortedVar, Term, VarBinding};
 pub use variable::VarDecl;
+#[cfg(feature = "z3")]
 pub use z3::theories::seq;
 
 /// defines a smtlib2 expression

--- a/src/z3/mod.rs
+++ b/src/z3/mod.rs
@@ -1,0 +1,1 @@
+pub mod theories;

--- a/src/z3/theories/mod.rs
+++ b/src/z3/theories/mod.rs
@@ -1,0 +1,1 @@
+pub mod seq;

--- a/src/z3/theories/seq.rs
+++ b/src/z3/theories/seq.rs
@@ -1,0 +1,73 @@
+use crate::{SortedVar, Term};
+
+fn seq_prefix(name: &str) -> String {
+    format!("seq.{name}")
+}
+
+pub fn unit(elem: Term) -> Term {
+    Term::fn_apply(seq_prefix("unit"), vec![elem])
+}
+
+pub fn empty(sort: String) -> Term {
+    Term::QualifiedIdentifier(SortedVar::new(seq_prefix("empty"), sort))
+}
+
+pub fn concat(seqs: Vec<Term>) -> Term {
+    Term::fn_apply(seq_prefix("++"), seqs)
+}
+
+pub fn len(seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("len"), vec![seq])
+}
+
+pub fn extract(seq: Term, offset: Term, length: Term) -> Term {
+    Term::fn_apply(seq_prefix("extract"), vec![seq, offset, length])
+}
+
+pub fn indexof(seq: Term, subseq: Term, offset: Option<Term>) -> Term {
+    let mut args = vec![seq, subseq];
+    if let Some(start_idx) = offset {
+        args.push(start_idx);
+    }
+    Term::fn_apply(seq_prefix("indexof"), args)
+}
+
+pub fn at(seq: Term, offset: Term) -> Term {
+    Term::fn_apply(seq_prefix("at"), vec![seq, offset])
+}
+
+pub fn nth(seq: Term, offset: Term) -> Term {
+    Term::fn_apply(seq_prefix("nth"), vec![seq, offset])
+}
+
+pub fn contains(seq: Term, subseq: Term) -> Term {
+    Term::fn_apply(seq_prefix("contains"), vec![seq, subseq])
+}
+
+pub fn prefixof(pre: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("prefixof"), vec![pre, seq])
+}
+
+pub fn suffixof(suf: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("suffixof"), vec![suf, seq])
+}
+
+pub fn replace(seq: Term, src: Term, dst: Term) -> Term {
+    Term::fn_apply(seq_prefix("replace"), vec![seq, src, dst])
+}
+
+pub fn map(fun: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("map"), vec![fun, seq])
+}
+
+pub fn mapi(fun: Term, offset: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("mapi"), vec![fun, offset, seq])
+}
+
+pub fn foldl(fun: Term, initial: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("foldl"), vec![fun, initial, seq])
+}
+
+pub fn foldli(fun: Term, offset: Term, initial: Term, seq: Term) -> Term {
+    Term::fn_apply(seq_prefix("foldli"), vec![fun, offset, initial, seq])
+}


### PR DESCRIPTION
- Added a `z3` feature for using `Seq` and `lambda`
- Added helpers for operating on `Seq`s: https://microsoft.github.io/z3guide/docs/theories/Sequences 